### PR TITLE
Fix marked and whole file tests

### DIFF
--- a/lua/neotest-busted/init.lua
+++ b/lua/neotest-busted/init.lua
@@ -275,11 +275,11 @@ end
 ---@return string
 ---@return string
 local function extract_test_info(pos)
-    local parts = vim.fn.split(pos.id, "::")
+    local parts = vim.split(pos.id, "::")
     local path = parts[1]
     local stripped_pos_id = table.concat(
         vim.tbl_map(function(part)
-            return vim.fn.trim(part, '"')
+            return util.trim(part, '"')
         end, vim.list_slice(parts, 2)),
         " "
     )

--- a/lua/neotest-busted/init.lua
+++ b/lua/neotest-busted/init.lua
@@ -160,6 +160,7 @@ local function create_busted_command(results_path, paths, filters)
     }
     -- stylua: ignore end
 
+    ---@type string[], string[]
     local lua_paths, lua_cpaths = {}, {}
 
     -- Append custom paths from config

--- a/lua/neotest-busted/util.lua
+++ b/lua/neotest-busted/util.lua
@@ -5,7 +5,7 @@ local lib = require("neotest.lib")
 --- Trim a character in both ends of a string
 ---@param value string
 ---@param char string
----@return unknown
+---@return string
 function util.trim(value, char)
     local start, _end = 1, #value
 
@@ -40,7 +40,7 @@ end
 
 ---@param ... string
 ---@return string
-function util.expand_and_create_lua_path(...)
+local function normalize_and_create_lua_path(...)
     return table.concat(vim.tbl_map(vim.fs.normalize, { ... }), ";")
 end
 
@@ -49,7 +49,7 @@ end
 ---@return string[]
 function util.create_package_path_argument(package_path, paths)
     if paths and #paths > 0 then
-        local _path = util.expand_and_create_lua_path(unpack(paths))
+        local _path = normalize_and_create_lua_path(unpack(paths))
 
         return { "-c", ([[lua %s = '%s;' .. %s]]):format(package_path, _path, package_path) }
     end

--- a/lua/neotest-busted/util.lua
+++ b/lua/neotest-busted/util.lua
@@ -14,22 +14,18 @@ function util.glob(path)
     return vim.fn.split(vim.fn.glob(path, true), "\n")
 end
 
----@param ... unknown
+---@param ... string
 ---@return string
 function util.expand_and_create_lua_path(...)
-    return table.concat(vim.tbl_map(vim.fn.expand, ...), ";")
+    return table.concat(vim.tbl_map(vim.fs.normalize, { ... }), ";")
 end
 
 ---@param package_path string lua package path type
----@param path string | string[] string to add to the lua package path
+---@param paths string[] string to add to the lua package path
 ---@return string[]
-function util.create_package_path_argument(package_path, path)
-    if path and #path > 0 then
-        local _path = path
-
-        if type(path) ~= "string" then
-            _path = util.expand_and_create_lua_path(path)
-        end
+function util.create_package_path_argument(package_path, paths)
+    if paths and #paths > 0 then
+        local _path = util.expand_and_create_lua_path(unpack(paths))
 
         return { "-c", ([[lua %s = '%s;' .. %s]]):format(package_path, _path, package_path) }
     end

--- a/lua/neotest-busted/util.lua
+++ b/lua/neotest-busted/util.lua
@@ -2,7 +2,7 @@ local util = {}
 
 local lib = require("neotest.lib")
 
---- Trim a string of a character in both ends
+--- Trim a character in both ends of a string
 ---@param value string
 ---@param char string
 ---@return unknown

--- a/lua/neotest-busted/util.lua
+++ b/lua/neotest-busted/util.lua
@@ -2,6 +2,30 @@ local util = {}
 
 local lib = require("neotest.lib")
 
+--- Trim a string of a character in both ends
+---@param value string
+---@param char string
+---@return unknown
+function util.trim(value, char)
+    local start, _end = 1, #value
+
+    for idx = 1, #value do
+        if value:sub(idx, idx) ~= char then
+            start = idx
+            break
+        end
+    end
+
+    for idx = #value, 1, -1 do
+        if value:sub(idx, idx) ~= char then
+            _end = idx
+            break
+        end
+    end
+
+    return value:sub(start, _end)
+end
+
 ---@param ... string
 ---@return string
 function util.create_path(...)

--- a/tests/adapter_build_spec_spec.lua
+++ b/tests/adapter_build_spec_spec.lua
@@ -81,7 +81,9 @@ describe("adapter.build_spec", function()
             "-c",
             ("lua package.path = '%s;' .. package.path"):format(lua_paths),
             "-c",
-            ("lua package.cpath = '%s;' .. package.cpath"):format(vim.fs.normalize(busted_cpaths[1])),
+            ("lua package.cpath = '%s;' .. package.cpath"):format(
+                vim.fs.normalize(busted_cpaths[1])
+            ),
             "-l",
             "./busted",
             "--output",

--- a/tests/adapter_build_spec_spec.lua
+++ b/tests/adapter_build_spec_spec.lua
@@ -65,7 +65,7 @@ describe("adapter.build_spec", function()
         assert.is_not_nil(spec)
 
         local lua_paths = table.concat({
-            vim.fn.expand(busted_paths[1]),
+            vim.fs.normalize(busted_paths[1]),
             "lua/?.lua",
             "lua/?/init.lua",
         }, ";")
@@ -81,7 +81,7 @@ describe("adapter.build_spec", function()
             "-c",
             ("lua package.path = '%s;' .. package.path"):format(lua_paths),
             "-c",
-            ("lua package.cpath = '%s;' .. package.cpath"):format(vim.fn.expand(busted_cpaths[1])),
+            ("lua package.cpath = '%s;' .. package.cpath"):format(vim.fs.normalize(busted_cpaths[1])),
             "-l",
             "./busted",
             "--output",

--- a/tests/util_spec.lua
+++ b/tests/util_spec.lua
@@ -1,0 +1,55 @@
+local util = require("neotest-busted.util")
+local lib = require("neotest.lib")
+
+describe("util", function()
+    describe("trim", function()
+        it("trims string", function()
+            assert.are.same(util.trim('"this will be trimmed"', '"'), 'this will be trimmed')
+            assert.are.same(util.trim('"this will not be trimmed"', '-'), '"this will not be trimmed"')
+        end)
+    end)
+
+    describe("create_path", function()
+        it("creates paths using os-specific path separator", function()
+            assert.are.same(util.create_path("some", "path"), 'some' .. lib.files.sep .. 'path')
+        end)
+    end)
+
+    describe("glob", function()
+        it("globs", function()
+            local path = util.create_path("lua", "**", "*.lua")
+
+            assert.are.same(util.glob(path), {
+                "lua/neotest-busted/init.lua",
+                "lua/neotest-busted/output_handler.lua",
+                "lua/neotest-busted/types.lua",
+                "lua/neotest-busted/util.lua",
+            })
+        end)
+    end)
+
+    describe("expand_and_create_lua_path", function()
+        it("expands paths and creates lua path", function()
+            local args = { "./lua\\neotest-busted", "tests/" }
+
+            assert.are.same(util.expand_and_create_lua_path(unpack(args)), "./lua/neotest-busted;tests")
+        end)
+    end)
+
+    describe("create_package_path_argument", function()
+        it("creates package path argument", function()
+            local args = { "some/path", "some/other/path" }
+
+            assert.are.same(util.create_package_path_argument("package.path", args), {
+                "-c",
+                "lua package.path = 'some/path;some/other/path;' .. package.path"
+            })
+        end)
+
+        it("handles nil or empty array", function()
+            ---@diagnostic disable-next-line: param-type-mismatch
+            assert.are.same(util.create_package_path_argument("package.path", nil), {})
+            assert.are.same(util.create_package_path_argument("package.path", {}), {})
+        end)
+    end)
+end)

--- a/tests/util_spec.lua
+++ b/tests/util_spec.lua
@@ -31,20 +31,9 @@ describe("util", function()
         end)
     end)
 
-    describe("expand_and_create_lua_path", function()
-        it("expands paths and creates lua path", function()
-            local args = { "./lua\\neotest-busted", "tests/" }
-
-            assert.are.same(
-                util.expand_and_create_lua_path(unpack(args)),
-                "./lua/neotest-busted;tests"
-            )
-        end)
-    end)
-
     describe("create_package_path_argument", function()
         it("creates package path argument", function()
-            local args = { "some/path", "some/other/path" }
+            local args = { "some/path", "some\\other/path" }
 
             assert.are.same(util.create_package_path_argument("package.path", args), {
                 "-c",

--- a/tests/util_spec.lua
+++ b/tests/util_spec.lua
@@ -4,14 +4,17 @@ local lib = require("neotest.lib")
 describe("util", function()
     describe("trim", function()
         it("trims string", function()
-            assert.are.same(util.trim('"this will be trimmed"', '"'), 'this will be trimmed')
-            assert.are.same(util.trim('"this will not be trimmed"', '-'), '"this will not be trimmed"')
+            assert.are.same(util.trim('"this will be trimmed"', '"'), "this will be trimmed")
+            assert.are.same(
+                util.trim('"this will not be trimmed"', "-"),
+                '"this will not be trimmed"'
+            )
         end)
     end)
 
     describe("create_path", function()
         it("creates paths using os-specific path separator", function()
-            assert.are.same(util.create_path("some", "path"), 'some' .. lib.files.sep .. 'path')
+            assert.are.same(util.create_path("some", "path"), "some" .. lib.files.sep .. "path")
         end)
     end)
 
@@ -32,7 +35,10 @@ describe("util", function()
         it("expands paths and creates lua path", function()
             local args = { "./lua\\neotest-busted", "tests/" }
 
-            assert.are.same(util.expand_and_create_lua_path(unpack(args)), "./lua/neotest-busted;tests")
+            assert.are.same(
+                util.expand_and_create_lua_path(unpack(args)),
+                "./lua/neotest-busted;tests"
+            )
         end)
     end)
 
@@ -42,7 +48,7 @@ describe("util", function()
 
             assert.are.same(util.create_package_path_argument("package.path", args), {
                 "-c",
-                "lua package.path = 'some/path;some/other/path;' .. package.path"
+                "lua package.path = 'some/path;some/other/path;' .. package.path",
             })
         end)
 


### PR DESCRIPTION
Using vim api functions, such as `vim.fn` functions, in an async context without checking for fast events via `vim.in_fast_event` causes neotest to silently mark tests as skipped when running marked tests via the summary or running the whole file more than once (passes the first time only).

Perhaps tests are run differently in different contexts.