### PR TITLE
Remove need for requiring busted runner script

### DIFF
--- a/lua/neotest-busted/busted-cli-runner.lua
+++ b/lua/neotest-busted/busted-cli-runner.lua
@@ -1,0 +1,1 @@
+require("busted.runner")({ standalone = false })

--- a/lua/neotest-busted/config.lua
+++ b/lua/neotest-busted/config.lua
@@ -105,6 +105,13 @@ end
 function config.configure(user_config)
     _user_config = vim.tbl_deep_extend("keep", user_config or {}, default_config)
 
+    if _user_config.busted_command ~= nil then
+        vim.notify_once(
+            "[neotest-busted]: busted_command is deprecated and will be removed in a future version",
+            vim.log.levels.WARN
+        )
+    end
+
     -- Skip checking the executable when running setup to avoid the error
     -- message as neotest loads all adapters so users will see an error in a
     -- non-lua/neovim directory with a relative path in `busted_command`

--- a/lua/neotest-busted/init.lua
+++ b/lua/neotest-busted/init.lua
@@ -263,7 +263,7 @@ function BustedNeotestAdapter.create_test_command(paths, options)
         if _options.results_path then
             vim.list_extend(busted_command_args, {
                 "--output",
-                get_path_to_plugin_file("output_handler.lua" ),
+                get_path_to_plugin_file("output_handler.lua"),
                 "-Xoutput",
                 _options.results_path,
             })
@@ -307,7 +307,6 @@ function BustedNeotestAdapter.create_test_command(paths, options)
     end
 
     return {
-        ---@diagnostic disable-next-line: undefined-field
         nvim_command = compat.loop.exepath(),
         arguments = arguments,
         paths = lua_paths,

--- a/lua/neotest-busted/types.lua
+++ b/lua/neotest-busted/types.lua
@@ -11,7 +11,7 @@ local types = {}
 
 ---@class neotest-busted.BustedCommandConfig
 ---@field type "config" | "project" | "user" | "global"
----@field command string
+---@field command string?
 ---@field lua_paths string[]
 ---@field lua_cpaths string[]
 

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -71,6 +71,13 @@ describe("config", function()
             assert
                 .stub(vim.notify_once).was
                 .called_with("[neotest-busted]: Invalid config: " .. tostring(error), vim.log.levels.ERROR)
+
+            if invalid_config_test.busted_command ~= nil then
+                assert.stub(vim.notify_once).was.called_with(
+                    "[neotest-busted]: busted_command is deprecated and will be removed in a future version",
+                    vim.log.levels.WARN
+                )
+            end
         end
 
         ---@diagnostic disable-next-line: undefined-field

--- a/tests/util_spec.lua
+++ b/tests/util_spec.lua
@@ -32,6 +32,7 @@ describe("util", function()
 
             assert.are.same(util.glob(path), {
                 "lua/neotest-busted/async.lua",
+                "lua/neotest-busted/busted-cli-runner.lua",
                 "lua/neotest-busted/busted-util.lua",
                 "lua/neotest-busted/cache.lua",
                 "lua/neotest-busted/compat.lua",


### PR DESCRIPTION
We do not actually need to use the busted lua script found in `BustedNeotestAdapter.find_busted_command` since that just calls `require("busted.runner")({ standalone = false })`. Instead, we can use our own script so we can have full control.

In fact, we might even consider removing the `busted_command` option, although it would be breaking change, since it has no real function and we cannot use the real busted binary as it is a shell script that runs busted through luarocks (we would need an `nlua` setup).